### PR TITLE
fix: attributes doubles when v-else-if exists

### DIFF
--- a/__tests__/fixtures/vuejs/slot.spec
+++ b/__tests__/fixtures/vuejs/slot.spec
@@ -1,0 +1,22 @@
+<div class="website">
+  <div class="webpage">
+    <h1 slot="webpageName">GeeksforGeeks</h1>
+  </div>
+  <div>
+    <h3 slot="webpageDesc">Computer science portal</h3>
+    <img src=
+"https://media.geeksforgeeks.org/wp-content/uploads/20210915115837/gfg3-300x300.png" 
+           slot="webpageImage">
+  </div>
+</div>
+---
+<div class="website">
+  <div class="webpage">
+    <h1 slot="webpageName">GeeksforGeeks</h1>
+  </div>
+  <div>
+    <h3 slot="webpageDesc">Computer science portal</h3>
+    <img slot="webpageImage" src=
+"https://media.geeksforgeeks.org/wp-content/uploads/20210915115837/gfg3-300x300.png">
+  </div>
+</div>

--- a/__tests__/fixtures/vuejs/v-else-if.spec
+++ b/__tests__/fixtures/vuejs/v-else-if.spec
@@ -1,0 +1,31 @@
+<q-card-section>
+    <span v-if="value.name === 'Name'">
+        <span v-if="!member.insurances.length">Name.</span>
+        <span v-else> Test </span>
+    </span>
+    <span v-else-if="value.name === 'Name1'">
+        <span v-if="!member.checks.length">Name1.</span>
+        <span v-else> Test </span>
+    </span>
+    <span v-else-if="value.name === 'Name2'">
+        <span v-if="!member.rights.length">Name2.</span>
+        <span v-else> Test </span>
+    </span>
+    <span v-else> Test </span>
+</q-card-section>
+---
+<q-card-section>
+    <span v-if="value.name === 'Name'">
+        <span v-if="!member.insurances.length">Name.</span>
+        <span v-else> Test </span>
+    </span>
+    <span v-else-if="value.name === 'Name1'">
+        <span v-if="!member.checks.length">Name1.</span>
+        <span v-else> Test </span>
+    </span>
+    <span v-else-if="value.name === 'Name2'">
+        <span v-if="!member.rights.length">Name2.</span>
+        <span v-else> Test </span>
+    </span>
+    <span v-else> Test </span>
+</q-card-section>

--- a/__tests__/fixtures/vuejs/v-slot.spec
+++ b/__tests__/fixtures/vuejs/v-slot.spec
@@ -1,0 +1,17 @@
+<MouseTracker v-slot="{ x, y }">
+  Mouse is at: {{ x }}, {{ y }}
+</MouseTracker>
+<BaseLayout>
+  <template v-slot:header>
+    <!-- content for the header slot -->
+  </template>
+</BaseLayout>
+---
+<MouseTracker v-slot="{ x, y }">
+  Mouse is at: {{ x }}, {{ y }}
+</MouseTracker>
+<BaseLayout>
+  <template v-slot:header>
+    <!-- content for the header slot -->
+  </template>
+</BaseLayout>

--- a/src/strategy/custom.ts
+++ b/src/strategy/custom.ts
@@ -1,4 +1,4 @@
-import { ISortOption } from "src/options";
+import { ISortOption } from "../options";
 import { SortStrategy } from "../sorter";
 
 /**

--- a/src/strategy/vuejs.ts
+++ b/src/strategy/vuejs.ts
@@ -36,7 +36,9 @@ export class VuejsStrategy implements SortStrategy {
 
         this.headingOrderedAttrsRegex.forEach((regex) => {
             attributes.forEach((attr) => {
-                if (new RegExp(`^${regex}(_attrs_\\d+___)?$`, 'gm').test(attr)) {
+                if (
+                    new RegExp(`^${regex}(_attrs_\\d+___)?$`, "gm").test(attr)
+                ) {
                     head.push(attr);
                 }
             });

--- a/src/strategy/vuejs.ts
+++ b/src/strategy/vuejs.ts
@@ -36,7 +36,7 @@ export class VuejsStrategy implements SortStrategy {
 
         this.headingOrderedAttrsRegex.forEach((regex) => {
             attributes.forEach((attr) => {
-                if (new RegExp(`^${regex}`).test(attr)) {
+                if (new RegExp(`^${regex}(_attrs_\\d+___)?$`, 'gm').test(attr)) {
                     head.push(attr);
                 }
             });


### PR DESCRIPTION
- fix: 🐛 fix: attribute doubles when v-else-if exists
- test: 💍 add test cases for vuejs strategy

## Context

- https://github.com/shufo/prettier-plugin-blade/issues/170

## Problem

When `v-else-if` attribiute exists and `vuejs` strategy is used

```html
<span v-else-if="value.name === 'Name2'"></span>
```

The attribute doubles like this.

```html
<span
  v-else-if="value.name === 'Name'"
  v-else-if="value.name === 'Name'"
></span>
```

Regex used in vuejs strategy causes this behaviour.

## Solution

Fixes regex to match attributes correctly.
